### PR TITLE
Add BiometricVectorConfidenceMethod to Data Model

### DIFF
--- a/index.html
+++ b/index.html
@@ -326,10 +326,10 @@ the [=holder=] has to unlock a device using multi-factor authentication.
 
     <p>
 A <dfn>BiometricVectorConfidenceMethod</dfn> enables an [=issuer=] to embed
-biometric embedding vectors in a [=verifiable credential=] so that a
-[=verifier=] can increase their confidence that the [=presentation|presenter=]
-is the same individual the [=issuer=] made [=claims=] about. Unlike raw
-biometric data (photos, audio recordings), embedding vectors are compact
+biometric vectors in a [=verifiable credential=] so that a [=verifier=] can
+increase their confidence that the [=presentation|presenter=] is the same
+individual the [=issuer=] made [=claims=] about. Unlike raw biometric data
+(e.g., photos, audio recordings), biometric _vectors_ are compact
 mathematical representations produced by a matching model. Vectors from
 different models are not interchangeable.
 </p>

--- a/index.html
+++ b/index.html
@@ -359,8 +359,8 @@ The capture format. Expected values include `video`, `static-image`,
 <dt>biometricModel</dt>
 <dd>
 An object identifying the matching model, containing a type property
-(MUST be BiometricMatchingModel) and a matchingModel property
-(vendor and model identifier, e.g., realeyes-2026-v3.2).
+(MUST be `BiometricMatchingModel`) and a `matchingModel` property
+(vendor and model identifier, e.g., `realeyes-2026-v3.2`).
 </dd>
 <dt>biometricVectors</dt>
 <dd>

--- a/index.html
+++ b/index.html
@@ -375,8 +375,8 @@ A biometric vector confidence method MAY also specify:
       <dt>`service`</dt>
       <dd>
 A service endpoint for server-assisted verification, following the service
-definition structure from [[DID-CORE]], containing id, type
-(BiometricVerificationService), and serviceEndpoint properties.
+definition structure from [[DID-CORE]], containing `id`, `type`
+(`BiometricVerificationService`), and `serviceEndpoint` properties.
 </dd>
 </dl>
     <p>

--- a/index.html
+++ b/index.html
@@ -429,8 +429,8 @@ confidence method for client-side verification:
 </pre>
       <p>
 The [=holder=]'s device captures a fresh biometric sample, compares it
-locally against the enrolled biometricVectors, and produces a
-BiometricVerificationCredential asserting the match:
+locally against the enrolled `biometricVectors`, and produces a
+`BiometricVerificationCredential` asserting the match:
 </p>
       <pre class="example" title="Verification output for client-side biometric match">
 {

--- a/index.html
+++ b/index.html
@@ -348,8 +348,8 @@ The value MUST be `BiometricVectorConfidenceMethod`.
 </dd>
 <dt>biometricType</dt>
 <dd>
-The biometric modality. Expected values include face, voice, fingerprint,
-palmprint, iris, and retina.
+The biometric modality. Expected values include `face`, `voice`, `fingerprint`,
+`palmprint`, `iris`, and `retina`.
 </dd>
 <dt>inputType</dt>
 <dd>

--- a/index.html
+++ b/index.html
@@ -512,11 +512,11 @@ confidence method that includes a service endpoint:
 }
 </pre>
       <p>
-The wallet reads the service property, presents the option to the
-[=holder=], and upon consent, transmits the biometricVectors and a fresh
-biometric capture to the serviceEndpoint. The service compares the
+The wallet reads the `service` property, presents the option to the
+[=holder=], and upon consent, transmits the `biometricVectors` and a fresh
+biometric capture to the `serviceEndpoint`. The service compares the
 fresh capture against the enrolled vectors and returns a signed
-BiometricVerificationCredential:
+`BiometricVerificationCredential`:
 </p>
       <pre class="example" title="Verification output for user-selected provider biometric match">
 {

--- a/index.html
+++ b/index.html
@@ -344,7 +344,7 @@ maintain multiple biometric enrollments for different contexts.
 </dd>
 <dt>type</dt>
 <dd>
-The value MUST be BiometricVectorConfidenceMethod.
+The value MUST be `BiometricVectorConfidenceMethod`.
 </dd>
 <dt>biometricType</dt>
 <dd>

--- a/index.html
+++ b/index.html
@@ -364,7 +364,7 @@ An object identifying the matching model, containing a type property
 </dd>
 <dt>biometricVectors</dt>
 <dd>
-Base64-encoded embedding vector. The format is specific to the matching
+Base64-encoded embedded vector. The format is specific to the matching
 model that generated it.
 </dd>
 </dl>

--- a/index.html
+++ b/index.html
@@ -353,8 +353,8 @@ The biometric modality. Expected values include `face`, `voice`, `fingerprint`,
 </dd>
 <dt>inputType</dt>
 <dd>
-The capture format. Expected values include video, static-image,
-image-sequence, and audio.
+The capture format. Expected values include `video`, `static-image`,
+`image-sequence`, and `audio`.
 </dd>
 <dt>biometricModel</dt>
 <dd>

--- a/index.html
+++ b/index.html
@@ -321,6 +321,236 @@ is based on a cryptographic key pair, but to produce a signature using that key,
 the [=holder=] has to unlock a device using multi-factor authentication.
       </p>
 
+  <section>
+    <h3>Biometric Vector Confidence Method</h3>
+
+    <p>
+A <dfn>BiometricVectorConfidenceMethod</dfn> enables an [=issuer=] to embed
+biometric embedding vectors in a [=verifiable credential=] so that a
+[=verifier=] can increase their confidence that the [=presentation|presenter=]
+is the same individual the [=issuer=] made [=claims=] about. Unlike raw
+biometric data (photos, audio recordings), embedding vectors are compact
+mathematical representations produced by a matching model. Vectors from
+different models are not interchangeable.
+</p>
+    <p>
+A biometric vector confidence method MUST specify the following properties:
+</p>
+    <dl>
+      <dt>`id`</dt>
+      <dd>
+A unique identifier for this confidence method instance. Enables a person to
+maintain multiple biometric enrollments for different contexts.
+</dd>
+<dt>type</dt>
+<dd>
+The value MUST be BiometricVectorConfidenceMethod.
+</dd>
+<dt>biometricType</dt>
+<dd>
+The biometric modality. Expected values include face, voice, fingerprint,
+palmprint, iris, and retina.
+</dd>
+<dt>inputType</dt>
+<dd>
+The capture format. Expected values include video, static-image,
+image-sequence, and audio.
+</dd>
+<dt>biometricModel</dt>
+<dd>
+An object identifying the matching model, containing a type property
+(MUST be BiometricMatchingModel) and a matchingModel property
+(vendor and model identifier, e.g., realeyes-2026-v3.2).
+</dd>
+<dt>biometricVectors</dt>
+<dd>
+Base64-encoded embedding vector. The format is specific to the matching
+model that generated it.
+</dd>
+</dl>
+    <p>
+A biometric vector confidence method MAY also specify:
+</p>
+    <dl>
+      <dt>`service`</dt>
+      <dd>
+A service endpoint for server-assisted verification, following the service
+definition structure from [[DID-CORE]], containing id, type
+(BiometricVerificationService), and serviceEndpoint properties.
+</dd>
+</dl>
+    <p>
+Two implementation scenarios are supported: client-side local processing
+and user-selected provider. In both cases, a fresh biometric sample is
+captured and compared against the enrolled vectors. The result is expressed
+as a BiometricVerificationCredential.
+</p>
+    <section>
+      <h4>Client-Side Verification</h4>
+
+      <p>
+In this scenario, biometric verification happens entirely on the
+[=holder=]'s device. No biometric data leaves the device; a zero-knowledge
+proof demonstrates the match.
+</p>
+      <p>
+The following example demonstrates a credential with a biometric vector
+confidence method for client-side verification:
+</p>
+      <pre class="example" title="Client-side biometric vector confidence method">
+{
+"@context": [
+"https://www.w3.org/ns/credentials/v2",
+"https://www.w3.org/ns/credentials/examples/v2"
+],
+"id": "http://example.edu/credentials/3732",
+"type": ["VerifiableCredential", "UniversityDegreeCredential"],
+"issuer": "https://example.edu/issuers/14",
+"validFrom": "2026-01-01T00:00:00Z",
+"credentialSubject": {
+"id": "did:example:ebfeb1f712ebc6f1c276e12ec21",
+"confidenceMethod": {
+"id": "urn:uuid:a7f8c3d1-4b2e-4f9a-8c6d-1e3b5a7f9c2d",
+"type": "BiometricVectorConfidenceMethod",
+"biometricType": "face",
+"inputType": "video",
+"biometricModel": {
+"type": "BiometricMatchingModel",
+"matchingModel": "realeyes-2026-v3.2"
+},
+"biometricVectors": "uAVvLMv6gm...MNam"
+},
+"degree": {
+"type": "BachelorDegree",
+"name": "Bachelor of Science"
+}
+}
+}
+</pre>
+      <p>
+The [=holder=]'s device captures a fresh biometric sample, compares it
+locally against the enrolled biometricVectors, and produces a
+BiometricVerificationCredential asserting the match:
+</p>
+      <pre class="example" title="Verification output for client-side biometric match">
+{
+"@context": [
+"https://www.w3.org/ns/credentials/v2",
+"https://www.w3.org/ns/credentials/examples/v2"
+],
+"type": ["VerifiableCredential", "BiometricVerificationCredential"],
+"issuer": "did:example:holder-device",
+"validFrom": "2026-05-15T14:30:00Z",
+"validUntil": "2026-05-15T14:45:00Z",
+"credentialSubject": {
+"id": "urn:uuid:a7f8c3d1-4b2e-4f9a-8c6d-1e3b5a7f9c2d",
+"biometricMatch": {
+"type": "BiometricMatch",
+"matchingMethod": "client-side-zkp",
+"matchDate": "2026-05-15T14:30:00Z",
+"matchResult": "verified",
+"confidence": "0.96"
+}
+},
+"proof": {
+"type": "DataIntegrityProof",
+"cryptosuite": "biometric-zkp-2026",
+"created": "2026-05-15T14:30:05Z",
+"verificationMethod": "did:example:holder-device#key-1",
+"proofPurpose": "authentication",
+"proofValue": "z58DAdFfa9SkqZMVPxAQpic7ndTeel..."
+}
+}
+</pre>
+</section>
+    <section>
+      <h4>User-Selected Provider</h4>
+
+      <p>
+In this scenario, the [=holder=] selects a trusted biometric verification
+service. The wallet presents available options and the [=holder=] consents
+before any biometric data is transmitted. The [=holder=]'s biometric data is
+sent only to their chosen provider, not to the [=verifier=].
+</p>
+      <p>
+The following example demonstrates a credential with a biometric vector
+confidence method that includes a service endpoint:
+</p>
+      <pre class="example" title="User-selected provider biometric vector confidence method">
+{
+"@context": [
+"https://www.w3.org/ns/credentials/v2",
+"https://www.w3.org/ns/credentials/examples/v2"
+],
+"id": "http://example.edu/credentials/3732",
+"type": ["VerifiableCredential", "UniversityDegreeCredential"],
+"issuer": "https://example.edu/issuers/14",
+"validFrom": "2026-01-01T00:00:00Z",
+"credentialSubject": {
+"id": "did:example:ebfeb1f712ebc6f1c276e12ec21",
+"confidenceMethod": {
+"id": "urn:uuid:a7f8c3d1-4b2e-4f9a-8c6d-1e3b5a7f9c2d",
+"type": "BiometricVectorConfidenceMethod",
+"biometricType": "face",
+"inputType": "video",
+"biometricModel": {
+"type": "BiometricMatchingModel",
+"matchingModel": "realeyes-2026-v3.2"
+},
+"service": {
+"id": "urn:uuid:service-1",
+"type": "BiometricVerificationService",
+"serviceEndpoint": "https://api.realeyesit.com/verify/v3"
+},
+"biometricVectors": "uAVvLMv6gm...MNam"
+},
+"degree": {
+"type": "BachelorDegree",
+"name": "Bachelor of Science"
+}
+}
+}
+</pre>
+      <p>
+The wallet reads the service property, presents the option to the
+[=holder=], and upon consent, transmits the biometricVectors and a fresh
+biometric capture to the serviceEndpoint. The service compares the
+fresh capture against the enrolled vectors and returns a signed
+BiometricVerificationCredential:
+</p>
+      <pre class="example" title="Verification output for user-selected provider biometric match">
+{
+"@context": [
+"https://www.w3.org/ns/credentials/v2",
+"https://www.w3.org/ns/credentials/examples/v2"
+],
+"type": ["VerifiableCredential", "BiometricVerificationCredential"],
+"issuer": "did:web:realeyesit.com",
+"validFrom": "2026-05-15T14:30:00Z",
+"validUntil": "2026-05-15T14:45:00Z",
+"credentialSubject": {
+"id": "urn:uuid:a7f8c3d1-4b2e-4f9a-8c6d-1e3b5a7f9c2d",
+"biometricMatch": {
+"type": "BiometricMatch",
+"matchingMethod": "server-assisted-video-stream",
+"matchDate": "2026-05-15T14:30:00Z",
+"domain": "https://verifier.example/",
+"matchResult": "verified",
+"confidence": "0.94"
+}
+},
+"proof": {
+"type": "DataIntegrityProof",
+"cryptosuite": "ecdsa-rdfc-2019",
+"created": "2026-05-15T14:30:05Z",
+"verificationMethod": "did:web:realeyesit.com#key-1",
+"proofPurpose": "assertionMethod",
+"proofValue": "z58DAdFfa9SkqZMVPxAQpic7ndTeel..."
+}
+}
+</pre>
+</section>
+</section>
     </section>
 
     <section>

--- a/index.html
+++ b/index.html
@@ -383,7 +383,7 @@ definition structure from [[DID-CORE]], containing id, type
 Two implementation scenarios are supported: client-side local processing
 and user-selected provider. In both cases, a fresh biometric sample is
 captured and compared against the enrolled vectors. The result is expressed
-as a BiometricVerificationCredential.
+as a `BiometricVerificationCredential`.
 </p>
     <section>
       <h4>Client-Side Verification</h4>

--- a/index.html
+++ b/index.html
@@ -358,7 +358,7 @@ The capture format. Expected values include `video`, `static-image`,
 </dd>
 <dt>biometricModel</dt>
 <dd>
-An object identifying the matching model, containing a type property
+An object identifying the matching model, containing a `type` property
 (MUST be `BiometricMatchingModel`) and a `matchingModel` property
 (vendor and model identifier, e.g., `realeyes-2026-v3.2`).
 </dd>

--- a/index.html
+++ b/index.html
@@ -321,83 +321,81 @@ is based on a cryptographic key pair, but to produce a signature using that key,
 the [=holder=] has to unlock a device using multi-factor authentication.
       </p>
 
-  <section>
+<section>
     <h3>Biometric Vector Confidence Method</h3>
-
-    <p>
+<p>
 A <dfn>BiometricVectorConfidenceMethod</dfn> enables an [=issuer=] to embed
 biometric vectors in a [=verifiable credential=] so that a [=verifier=] can
 increase their confidence that the [=presentation|presenter=] is the same
 individual the [=issuer=] made [=claims=] about. Unlike raw biometric data
-(e.g., photos, audio recordings), biometric _vectors_ are compact
+(e.g., photos, audio recordings), biometric <em>vectors</em> are compact
 mathematical representations produced by a matching model. Vectors from
 different models are not interchangeable.
 </p>
-    <p>
+<p>
 A biometric vector confidence method MUST specify the following properties:
 </p>
-    <dl>
-      <dt>`id`</dt>
-      <dd>
+<dl>
+<dt>id</dt>
+<dd>
 A unique identifier for this confidence method instance. Enables a person to
 maintain multiple biometric enrollments for different contexts.
 </dd>
 <dt>type</dt>
 <dd>
-The value MUST be `BiometricVectorConfidenceMethod`.
+The value MUST be BiometricVectorConfidenceMethod.
 </dd>
 <dt>biometricType</dt>
 <dd>
-The biometric modality. Expected values include `face`, `voice`, `fingerprint`,
-`palmprint`, `iris`, and `retina`.
+The biometric modality. Expected values include face, voice, fingerprint,
+palmprint, iris, and retina.
 </dd>
 <dt>inputType</dt>
 <dd>
-The capture format. Expected values include `video`, `static-image`,
-`image-sequence`, and `audio`.
+The capture format. Expected values include video, static-image,
+image-sequence, and audio.
 </dd>
 <dt>biometricModel</dt>
 <dd>
-An object identifying the matching model, containing a `type` property
-(MUST be `BiometricMatchingModel`) and a `matchingModel` property
-(vendor and model identifier, e.g., `realeyes-2026-v3.2`).
+An object identifying the matching model, containing a type property
+(MUST be BiometricMatchingModel) and a matchingModel property
+(vendor and model identifier, e.g., realeyes-2026-v3.2).
 </dd>
 <dt>biometricVectors</dt>
 <dd>
-Base64-encoded embedded vector. The format is specific to the matching
-model that generated it.
+Multibase-encoded (base64url-nopad) biometric vector. The format is specific
+to the matching model that generated it.
 </dd>
 </dl>
-    <p>
+<p>
 A biometric vector confidence method MAY also specify:
 </p>
-    <dl>
-      <dt>`service`</dt>
-      <dd>
+<dl>
+<dt>service</dt>
+<dd>
 A service endpoint for server-assisted verification, following the service
-definition structure from [[DID-CORE]], containing `id`, `type`
-(`BiometricVerificationService`), and `serviceEndpoint` properties.
+definition structure from [[DID-CORE]], containing id, type
+(BiometricVerificationService), and serviceEndpoint properties.
 </dd>
 </dl>
-    <p>
+<p>
 Two implementation scenarios are supported: client-side local processing
 and user-selected provider. In both cases, a fresh biometric sample is
 captured and compared against the enrolled vectors. The result is expressed
-as a `BiometricVerificationCredential`.
+as a BiometricVerificationCredential.
 </p>
-    <section>
-      <h4>Client-Side Verification</h4>
-
-      <p>
+<section>
+<h4>Client-Side Verification</h4>
+  <p>
 In this scenario, biometric verification happens entirely on the
 [=holder=]'s device. No biometric data leaves the device; a zero-knowledge
 proof demonstrates the match.
 </p>
-      <p>
+<p>
 The following example demonstrates a credential with a biometric vector
 confidence method for client-side verification:
 </p>
-      <pre class="example" title="Client-side biometric vector confidence method">
+<pre class="example" title="Client-side biometric vector confidence method">
 {
 "@context": [
 "https://www.w3.org/ns/credentials/v2",
@@ -427,12 +425,12 @@ confidence method for client-side verification:
 }
 }
 </pre>
-      <p>
+  <p>
 The [=holder=]'s device captures a fresh biometric sample, compares it
-locally against the enrolled `biometricVectors`, and produces a
-`BiometricVerificationCredential` asserting the match:
+locally against the enrolled biometricVectors, and produces a
+BiometricVerificationCredential asserting the match:
 </p>
-      <pre class="example" title="Verification output for client-side biometric match">
+<pre class="example" title="Verification output for client-side biometric match">
 {
 "@context": [
 "https://www.w3.org/ns/credentials/v2",
@@ -463,20 +461,19 @@ locally against the enrolled `biometricVectors`, and produces a
 }
 </pre>
 </section>
-    <section>
-      <h4>User-Selected Provider</h4>
-
-      <p>
+<section>
+<h4>User-Selected Provider</h4>
+  <p>
 In this scenario, the [=holder=] selects a trusted biometric verification
 service. The wallet presents available options and the [=holder=] consents
 before any biometric data is transmitted. The [=holder=]'s biometric data is
 sent only to their chosen provider, not to the [=verifier=].
 </p>
-      <p>
+<p>
 The following example demonstrates a credential with a biometric vector
 confidence method that includes a service endpoint:
 </p>
-      <pre class="example" title="User-selected provider biometric vector confidence method">
+<pre class="example" title="User-selected provider biometric vector confidence method">
 {
 "@context": [
 "https://www.w3.org/ns/credentials/v2",
@@ -511,14 +508,30 @@ confidence method that includes a service endpoint:
 }
 }
 </pre>
-      <p>
-The wallet reads the `service` property, presents the option to the
-[=holder=], and upon consent, transmits the `biometricVectors` and a fresh
-biometric capture to the `serviceEndpoint`. The service compares the
-fresh capture against the enrolled vectors and returns a signed
-`BiometricVerificationCredential`:
+  <p>
+The verification flow ensures that the biometric provider and [=verifier=]
+do not need to know about each other:
 </p>
-      <pre class="example" title="Verification output for user-selected provider biometric match">
+  <ol>
+    <li>The [=verifier=] requests biometric verification from the
+[=holder=], specifying accepted biometric providers and a challenge nonce.</li>
+<li>The wallet presents the accepted providers to the [=holder=],
+who selects their preferred provider and consents to the verification.</li>
+<li>The wallet transmits the biometricVectors, a fresh
+biometric capture, and the challenge nonce to the selected provider's
+serviceEndpoint.</li>
+<li>The provider compares the fresh capture against the enrolled
+vectors and issues a signed BiometricVerificationCredential
+with the challenge nonce embedded.</li>
+<li>The wallet presents the BiometricVerificationCredential
+to the [=verifier=], who validates the proof and checks the embedded challenge
+matches their original request.</li>
+</ol>
+  <p>
+The challenge nonce prevents replay attacks and proves the verification
+was performed in response to the [=verifier=]'s specific request:
+</p>
+<pre class="example" title="Verification output for user-selected provider biometric match">
 {
 "@context": [
 "https://www.w3.org/ns/credentials/v2",
@@ -550,7 +563,7 @@ fresh capture against the enrolled vectors and returns a signed
 }
 </pre>
 </section>
-</section>
+  </section>
     </section>
 
     <section>

--- a/index.html
+++ b/index.html
@@ -722,8 +722,8 @@ confidence method for client-side verification:
 </pre>
   <p>
 The [=holder=]'s device captures a fresh biometric sample, compares it
-locally against the enrolled biometricVectors, and produces a
-BiometricVerificationCredential asserting the match:
+locally against the enrolled `biometricVectors`, and produces a
+`BiometricVerificationCredential` asserting the match:
 </p>
 <pre class="example" title="Verification output for client-side biometric match">
 {

--- a/index.html
+++ b/index.html
@@ -649,6 +649,20 @@ method</a>, such as a public key, by
     <section>
       <h3>Biometric Vector Confidence Method</h3>
       <p>
+      <p class="issue atrisk" title="This feature is unstable and continues to be refined by the Task Force">
+The Biometric Vector Confidence Method is unstable and continues to be refined by the Task Force. The following concerns are actively being worked on at present: <br>
+1) The specification needs to be agnostic to biometric matching providers and not favor any particular proprietary or open approach/types. <br>
+2) Model/vector data might be combined since they are associated with one another. It doesn't really make sense to decouple the model and the vector information. base64url encoded CBOR might be a better approach to hold this information.<br>
+3) How do we specify examples with open matching models, which need to exist in the spec.<br>
+4) Clarify that the issuer can provide multiple vectors from different providers when the credential is issued.<br>
+5) There is no standardized ZKP to do biometric matching yet, but the group believes that is the ideal end-state.<br>
+6) Issuers putting service URLs into the biometric matching model might not be the best design and will need to be refined. More work will need to be done to figure out how the negotiation is performed between the holder and the verifier, and the holder and the issuer.<br>
+7) Where should this information be published? Is it safe to put this in the DID Document?<br>
+8) Describe "ideal state" use cases in the specification.<br>
+9) How do holder's find "the right" biometric provider? Is it asking too much of the holder? Is that a security/privacy risk? How much are we asking holder's to do?<br>
+10) Do application integrity checks need to be performed for local device checks?<br>
+11) Nonces need to be added to the model.<br>
+      </p>
         A <dfn>BiometricVectorConfidenceMethod</dfn> enables an [=issuer=] to embed
         biometric <em>vectors</em> in a [=verifiable credential=] so that a
         [=verifier=] can increase their confidence that the

--- a/index.html
+++ b/index.html
@@ -700,9 +700,9 @@ method</a>, such as a public key, by
         <dt>`service`</dt>
         <dd>
           A service endpoint for server-assisted verification, following the
-          service definition structure from [[DID-CORE]], containing `id`,
-          `type` (`BiometricVerificationService`), and `serviceEndpoint`
-          properties.
+          service definition structure from [[[DID-CORE]]] [[DID-CORE]],
+          containing `id`, `type` (`BiometricVerificationService`), and
+          `serviceEndpoint` properties.
         </dd>
       </dl>
       <p>

--- a/index.html
+++ b/index.html
@@ -755,7 +755,10 @@ method</a>, such as a public key, by
         <p>
           The [=holder=]'s device captures a fresh biometric sample, compares it
           locally against the enrolled `biometricVectors`, and produces a
-          `BiometricVerificationCredential` asserting the match:
+          `BiometricVerificationCredential` asserting the match. Note that the
+          `credentialSubject.id` in the verification output references the
+          confidence method `id` from the credential above, linking the
+          verification result to the specific biometric enrollment:
         </p>
         <pre class="example" title="Verification output for client-side biometric match">
   {
@@ -777,7 +780,7 @@ method</a>, such as a public key, by
         "confidence": "0.96"
       }
     },
-"proof": {
+    "proof": {
       "type": "DataIntegrityProof",
       "cryptosuite": "example-biometric-zkp-2028",
       "created": "2026-05-15T14:30:05Z",
@@ -787,7 +790,7 @@ method</a>, such as a public key, by
     }
   }
         </pre>
-        <p class="note">
+        <p class="issue atrisk">
           The `example-biometric-zkp-2028` cryptosuite does not exist at the
           time of this writing. It is included here to illustrate how a future
           zero-knowledge proof cryptosuite could be used for client-side
@@ -865,7 +868,10 @@ method</a>, such as a public key, by
         </ol>
         <p>
           The challenge nonce prevents replay attacks and proves the verification
-          was performed in response to the [=verifier=]'s specific request:
+          was performed in response to the [=verifier=]'s specific request.
+          As with the client-side scenario, the `credentialSubject.id` in the
+          verification output references the confidence method `id` from the
+          credential above:
         </p>
         <pre class="example" title="Verification output for user-selected provider biometric match">
   {
@@ -900,7 +906,6 @@ method</a>, such as a public key, by
         </pre>
       </section>
     </section>
-  </section>
 
   <section>
     <h2>Assurance Levels</h2>

--- a/index.html
+++ b/index.html
@@ -676,7 +676,7 @@ method</a>, such as a public key, by
           The biometric modality. Expected values include `face`, `voice`,
           `fingerprint`, `palmprint`, `iris`, and `retina`.
         </dd>
-        <dt>`inputType`</dt>
+        <dt>`captureFormat`</dt>
         <dd>
           The capture format. Expected values include `video`, `static-image`,
           `image-sequence`, and `audio`.

--- a/index.html
+++ b/index.html
@@ -616,250 +616,8 @@ method</a>, such as a public key, by
       authentication.
     </p>
 
-<section>
-    <h3>Biometric Vector Confidence Method</h3>
-<p>
-A <dfn>BiometricVectorConfidenceMethod</dfn> enables an [=issuer=] to embed
-biometric vectors in a [=verifiable credential=] so that a [=verifier=] can
-increase their confidence that the [=presentation|presenter=] is the same
-individual the [=issuer=] made [=claims=] about. Unlike raw biometric data
-(e.g., photos, audio recordings), biometric <em>vectors</em> are compact
-mathematical representations produced by a matching model. Vectors from
-different models are not interchangeable.
-</p>
-<p>
-A biometric vector confidence method MUST specify the following properties:
-</p>
-<dl>
-<dt>id</dt>
-<dd>
-A unique identifier for this confidence method instance. Enables a person to
-maintain multiple biometric enrollments for different contexts.
-</dd>
-<dt>type</dt>
-<dd>
-The value MUST be BiometricVectorConfidenceMethod.
-</dd>
-<dt>biometricType</dt>
-<dd>
-The biometric modality. Expected values include face, voice, fingerprint,
-palmprint, iris, and retina.
-</dd>
-<dt>inputType</dt>
-<dd>
-The capture format. Expected values include video, static-image,
-image-sequence, and audio.
-</dd>
-<dt>biometricModel</dt>
-<dd>
-An object identifying the matching model, containing a type property
-(MUST be BiometricMatchingModel) and a matchingModel property
-(vendor and model identifier, e.g., realeyes-2026-v3.2).
-</dd>
-<dt>biometricVectors</dt>
-<dd>
-Multibase-encoded (base64url-nopad) biometric vector. The format is specific
-to the matching model that generated it.
-</dd>
-</dl>
-<p>
-A biometric vector confidence method MAY also specify:
-</p>
-<dl>
-<dt>service</dt>
-<dd>
-A service endpoint for server-assisted verification, following the service
-definition structure from [[DID-CORE]], containing id, type
-(BiometricVerificationService), and serviceEndpoint properties.
-</dd>
-</dl>
-<p>
-Two implementation scenarios are supported: client-side local processing
-and user-selected provider. In both cases, a fresh biometric sample is
-captured and compared against the enrolled vectors. The result is expressed
-as a BiometricVerificationCredential.
-</p>
-<section>
-<h4>Client-Side Verification</h4>
-  <p>
-In this scenario, biometric verification happens entirely on the
-[=holder=]'s device. No biometric data leaves the device; a zero-knowledge
-proof demonstrates the match.
-</p>
-<p>
-The following example demonstrates a credential with a biometric vector
-confidence method for client-side verification:
-</p>
-<pre class="example" title="Client-side biometric vector confidence method">
-{
-"@context": [
-"https://www.w3.org/ns/credentials/v2",
-"https://www.w3.org/ns/credentials/examples/v2"
-],
-"id": "http://example.edu/credentials/3732",
-"type": ["VerifiableCredential", "UniversityDegreeCredential"],
-"issuer": "https://example.edu/issuers/14",
-"validFrom": "2026-01-01T00:00:00Z",
-"credentialSubject": {
-"id": "did:example:ebfeb1f712ebc6f1c276e12ec21",
-"confidenceMethod": {
-"id": "urn:uuid:a7f8c3d1-4b2e-4f9a-8c6d-1e3b5a7f9c2d",
-"type": "BiometricVectorConfidenceMethod",
-"biometricType": "face",
-"inputType": "video",
-"biometricModel": {
-"type": "BiometricMatchingModel",
-"matchingModel": "realeyes-2026-v3.2"
-},
-"biometricVectors": "uAVvLMv6gm...MNam"
-},
-"degree": {
-"type": "BachelorDegree",
-"name": "Bachelor of Science"
-}
-}
-}
-</pre>
-  <p>
-The [=holder=]'s device captures a fresh biometric sample, compares it
-locally against the enrolled `biometricVectors`, and produces a
-`BiometricVerificationCredential` asserting the match:
-</p>
-<pre class="example" title="Verification output for client-side biometric match">
-{
-"@context": [
-"https://www.w3.org/ns/credentials/v2",
-"https://www.w3.org/ns/credentials/examples/v2"
-],
-"type": ["VerifiableCredential", "BiometricVerificationCredential"],
-"issuer": "did:example:holder-device",
-"validFrom": "2026-05-15T14:30:00Z",
-"validUntil": "2026-05-15T14:45:00Z",
-"credentialSubject": {
-"id": "urn:uuid:a7f8c3d1-4b2e-4f9a-8c6d-1e3b5a7f9c2d",
-"biometricMatch": {
-"type": "BiometricMatch",
-"matchingMethod": "client-side-zkp",
-"matchDate": "2026-05-15T14:30:00Z",
-"matchResult": "verified",
-"confidence": "0.96"
-}
-},
-"proof": {
-"type": "DataIntegrityProof",
-"cryptosuite": "biometric-zkp-2026",
-"created": "2026-05-15T14:30:05Z",
-"verificationMethod": "did:example:holder-device#key-1",
-"proofPurpose": "authentication",
-"proofValue": "z58DAdFfa9SkqZMVPxAQpic7ndTeel..."
-}
-}
-</pre>
-</section>
-<section>
-<h4>User-Selected Provider</h4>
-  <p>
-In this scenario, the [=holder=] selects a trusted biometric verification
-service. The wallet presents available options and the [=holder=] consents
-before any biometric data is transmitted. The [=holder=]'s biometric data is
-sent only to their chosen provider, not to the [=verifier=].
-</p>
-<p>
-The following example demonstrates a credential with a biometric vector
-confidence method that includes a service endpoint:
-</p>
-<pre class="example" title="User-selected provider biometric vector confidence method">
-{
-"@context": [
-"https://www.w3.org/ns/credentials/v2",
-"https://www.w3.org/ns/credentials/examples/v2"
-],
-"id": "http://example.edu/credentials/3732",
-"type": ["VerifiableCredential", "UniversityDegreeCredential"],
-"issuer": "https://example.edu/issuers/14",
-"validFrom": "2026-01-01T00:00:00Z",
-"credentialSubject": {
-"id": "did:example:ebfeb1f712ebc6f1c276e12ec21",
-"confidenceMethod": {
-"id": "urn:uuid:a7f8c3d1-4b2e-4f9a-8c6d-1e3b5a7f9c2d",
-"type": "BiometricVectorConfidenceMethod",
-"biometricType": "face",
-"inputType": "video",
-"biometricModel": {
-"type": "BiometricMatchingModel",
-"matchingModel": "realeyes-2026-v3.2"
-},
-"service": {
-"id": "urn:uuid:service-1",
-"type": "BiometricVerificationService",
-"serviceEndpoint": "https://api.realeyesit.com/verify/v3"
-},
-"biometricVectors": "uAVvLMv6gm...MNam"
-},
-"degree": {
-"type": "BachelorDegree",
-"name": "Bachelor of Science"
-}
-}
-}
-</pre>
-  <p>
-The verification flow ensures that the biometric provider and [=verifier=]
-do not need to know about each other:
-</p>
-  <ol>
-    <li>The [=verifier=] requests biometric verification from the
-[=holder=], specifying accepted biometric providers and a challenge nonce.</li>
-<li>The wallet presents the accepted providers to the [=holder=],
-who selects their preferred provider and consents to the verification.</li>
-<li>The wallet transmits the biometricVectors, a fresh
-biometric capture, and the challenge nonce to the selected provider's
-serviceEndpoint.</li>
-<li>The provider compares the fresh capture against the enrolled
-vectors and issues a signed BiometricVerificationCredential
-with the challenge nonce embedded.</li>
-<li>The wallet presents the BiometricVerificationCredential
-to the [=verifier=], who validates the proof and checks the embedded challenge
-matches their original request.</li>
-</ol>
-  <p>
-The challenge nonce prevents replay attacks and proves the verification
-was performed in response to the [=verifier=]'s specific request:
-</p>
-<pre class="example" title="Verification output for user-selected provider biometric match">
-{
-"@context": [
-"https://www.w3.org/ns/credentials/v2",
-"https://www.w3.org/ns/credentials/examples/v2"
-],
-"type": ["VerifiableCredential", "BiometricVerificationCredential"],
-"issuer": "did:web:realeyesit.com",
-"validFrom": "2026-05-15T14:30:00Z",
-"validUntil": "2026-05-15T14:45:00Z",
-"credentialSubject": {
-"id": "urn:uuid:a7f8c3d1-4b2e-4f9a-8c6d-1e3b5a7f9c2d",
-"biometricMatch": {
-"type": "BiometricMatch",
-"matchingMethod": "server-assisted-video-stream",
-"matchDate": "2026-05-15T14:30:00Z",
-"domain": "https://verifier.example/",
-"matchResult": "verified",
-"confidence": "0.94"
-}
-},
-"proof": {
-"type": "DataIntegrityProof",
-"cryptosuite": "ecdsa-rdfc-2019",
-"created": "2026-05-15T14:30:05Z",
-"verificationMethod": "did:web:realeyesit.com#key-1",
-"proofPurpose": "assertionMethod",
-"proofValue": "z58DAdFfa9SkqZMVPxAQpic7ndTeel..."
-}
-}
-</pre>
-</section>
   </section>
-  </section>
+
   <section>
     <h2>Confidence Methods</h2>
     <dl>
@@ -888,7 +646,256 @@ was performed in response to the [=verifier=]'s specific request:
       <h3>Biometric Image Confidence</h3>
       <p>TBD</p>
     </section>
+    <section>
+      <h3>Biometric Vector Confidence Method</h3>
+      <p>
+        A <dfn>BiometricVectorConfidenceMethod</dfn> enables an [=issuer=] to embed
+        biometric <em>vectors</em> in a [=verifiable credential=] so that a
+        [=verifier=] can increase their confidence that the
+        [=presentation|presenter=] is the same individual the [=issuer=] made
+        [=claims=] about. Unlike raw biometric data (e.g., photos, audio
+        recordings), biometric <em>vectors</em> are compact mathematical
+        representations produced by a matching model. Vectors from different
+        models are not interchangeable.
+      </p>
+      <p>
+        A biometric vector confidence method MUST specify the following properties:
+      </p>
+      <dl>
+        <dt>`id`</dt>
+        <dd>
+          A unique identifier for this confidence method instance. Enables a
+          person to maintain multiple biometric enrollments for different contexts.
+        </dd>
+        <dt>`type`</dt>
+        <dd>
+          The value MUST be `BiometricVectorConfidenceMethod`.
+        </dd>
+        <dt>`biometricType`</dt>
+        <dd>
+          The biometric modality. Expected values include `face`, `voice`,
+          `fingerprint`, `palmprint`, `iris`, and `retina`.
+        </dd>
+        <dt>`inputType`</dt>
+        <dd>
+          The capture format. Expected values include `video`, `static-image`,
+          `image-sequence`, and `audio`.
+        </dd>
+        <dt>`biometricModel`</dt>
+        <dd>
+          An object identifying the matching model, containing a `type` property
+          (MUST be `BiometricMatchingModel`) and a `matchingModel` property
+          (vendor and model identifier, e.g., `realeyes-2026-v3.2`).
+        </dd>
+        <dt>`biometricVectors`</dt>
+        <dd>
+          Multibase-encoded (base64url-nopad) biometric vector. The format is
+          specific to the matching model that generated it.
+        </dd>
+      </dl>
+      <p>
+        A biometric vector confidence method MAY also specify:
+      </p>
+      <dl>
+        <dt>`service`</dt>
+        <dd>
+          A service endpoint for server-assisted verification, following the
+          service definition structure from [[DID-CORE]], containing `id`,
+          `type` (`BiometricVerificationService`), and `serviceEndpoint`
+          properties.
+        </dd>
+      </dl>
+      <p>
+        Two implementation scenarios are supported: client-side local processing
+        and user-selected provider. In both cases, a fresh biometric sample is
+        captured and compared against the enrolled vectors. The result is
+        expressed as a `BiometricVerificationCredential`.
+      </p>
+      <section>
+        <h4>Client-Side Verification</h4>
+        <p>
+          In this scenario, biometric verification happens entirely on the
+          [=holder=]'s device. No biometric data leaves the device; a
+          zero-knowledge proof demonstrates the match.
+        </p>
+        <p>
+          The following example demonstrates a credential with a biometric vector
+          confidence method for client-side verification:
+        </p>
+        <pre class="example" title="Client-side biometric vector confidence method">
+  {
+    "@context": [
+      "https://www.w3.org/ns/credentials/v2",
+      "https://www.w3.org/ns/credentials/examples/v2"
+    ],
+    "id": "http://example.edu/credentials/3732",
+    "type": ["VerifiableCredential", "UniversityDegreeCredential"],
+    "issuer": "https://example.edu/issuers/14",
+    "validFrom": "2026-01-01T00:00:00Z",
+    "credentialSubject": {
+      "id": "did:example:ebfeb1f712ebc6f1c276e12ec21",
+      "confidenceMethod": {
+        "id": "urn:uuid:a7f8c3d1-4b2e-4f9a-8c6d-1e3b5a7f9c2d",
+        "type": "BiometricVectorConfidenceMethod",
+        "biometricType": "face",
+        "inputType": "video",
+        "biometricModel": {
+          "type": "BiometricMatchingModel",
+          "matchingModel": "realeyes-2026-v3.2"
+        },
+        "biometricVectors": "uAVvLMv6gm...MNam"
+      },
+      "degree": {
+        "type": "BachelorDegree",
+        "name": "Bachelor of Science"
+      }
+    }
+  }
+        </pre>
+        <p>
+          The [=holder=]'s device captures a fresh biometric sample, compares it
+          locally against the enrolled `biometricVectors`, and produces a
+          `BiometricVerificationCredential` asserting the match:
+        </p>
+        <pre class="example" title="Verification output for client-side biometric match">
+  {
+    "@context": [
+      "https://www.w3.org/ns/credentials/v2",
+      "https://www.w3.org/ns/credentials/examples/v2"
+    ],
+    "type": ["VerifiableCredential", "BiometricVerificationCredential"],
+    "issuer": "did:example:holder-device",
+    "validFrom": "2026-05-15T14:30:00Z",
+    "validUntil": "2026-05-15T14:45:00Z",
+    "credentialSubject": {
+      "id": "urn:uuid:a7f8c3d1-4b2e-4f9a-8c6d-1e3b5a7f9c2d",
+      "biometricMatch": {
+        "type": "BiometricMatch",
+        "matchingMethod": "client-side-zkp",
+        "matchDate": "2026-05-15T14:30:00Z",
+        "matchResult": "verified",
+        "confidence": "0.96"
+      }
+    },
+    "proof": {
+      "type": "DataIntegrityProof",
+      "cryptosuite": "biometric-zkp-2026",
+      "created": "2026-05-15T14:30:05Z",
+      "verificationMethod": "did:example:holder-device#key-1",
+      "proofPurpose": "authentication",
+      "proofValue": "z58DAdFfa9SkqZMVPxAQpic7ndTeel..."
+    }
+  }
+        </pre>
+      </section>
+      <section>
+        <h4>User-Selected Provider</h4>
+        <p>
+          In this scenario, the [=holder=] selects a trusted biometric
+          verification service. The wallet presents available options and the
+          [=holder=] consents before any biometric data is transmitted. The
+          [=holder=]'s biometric data is sent only to their chosen provider, not
+          to the [=verifier=].
+        </p>
+        <p>
+          The following example demonstrates a credential with a biometric vector
+          confidence method that includes a service endpoint:
+        </p>
+        <pre class="example" title="User-selected provider biometric vector confidence method">
+  {
+    "@context": [
+      "https://www.w3.org/ns/credentials/v2",
+      "https://www.w3.org/ns/credentials/examples/v2"
+    ],
+    "id": "http://example.edu/credentials/3732",
+    "type": ["VerifiableCredential", "UniversityDegreeCredential"],
+    "issuer": "https://example.edu/issuers/14",
+    "validFrom": "2026-01-01T00:00:00Z",
+    "credentialSubject": {
+      "id": "did:example:ebfeb1f712ebc6f1c276e12ec21",
+      "confidenceMethod": {
+        "id": "urn:uuid:a7f8c3d1-4b2e-4f9a-8c6d-1e3b5a7f9c2d",
+        "type": "BiometricVectorConfidenceMethod",
+        "biometricType": "face",
+        "inputType": "video",
+        "biometricModel": {
+          "type": "BiometricMatchingModel",
+          "matchingModel": "realeyes-2026-v3.2"
+        },
+        "service": {
+          "id": "urn:uuid:service-1",
+          "type": "BiometricVerificationService",
+          "serviceEndpoint": "https://api.realeyesit.com/verify/v3"
+        },
+        "biometricVectors": "uAVvLMv6gm...MNam"
+      },
+      "degree": {
+        "type": "BachelorDegree",
+        "name": "Bachelor of Science"
+      }
+    }
+  }
+        </pre>
+        <p>
+          The verification flow ensures that the biometric provider and
+          [=verifier=] do not need to know about each other:
+        </p>
+        <ol>
+          <li>The [=verifier=] requests biometric verification from the
+            [=holder=], specifying accepted biometric providers and a challenge
+            nonce.</li>
+          <li>The wallet presents the accepted providers to the [=holder=], who
+            selects their preferred provider and consents to the
+            verification.</li>
+          <li>The wallet transmits the `biometricVectors`, a fresh biometric
+            capture, and the challenge nonce to the selected provider's
+            `serviceEndpoint`.</li>
+          <li>The provider compares the fresh capture against the enrolled
+            vectors and issues a signed `BiometricVerificationCredential` with
+            the challenge nonce embedded.</li>
+          <li>The wallet presents the `BiometricVerificationCredential` to the
+            [=verifier=], who validates the proof and checks the embedded
+            challenge matches their original request.</li>
+        </ol>
+        <p>
+          The challenge nonce prevents replay attacks and proves the verification
+          was performed in response to the [=verifier=]'s specific request:
+        </p>
+        <pre class="example" title="Verification output for user-selected provider biometric match">
+  {
+    "@context": [
+      "https://www.w3.org/ns/credentials/v2",
+      "https://www.w3.org/ns/credentials/examples/v2"
+    ],
+    "type": ["VerifiableCredential", "BiometricVerificationCredential"],
+    "issuer": "did:web:realeyesit.com",
+    "validFrom": "2026-05-15T14:30:00Z",
+    "validUntil": "2026-05-15T14:45:00Z",
+    "credentialSubject": {
+      "id": "urn:uuid:a7f8c3d1-4b2e-4f9a-8c6d-1e3b5a7f9c2d",
+      "biometricMatch": {
+        "type": "BiometricMatch",
+        "matchingMethod": "server-assisted-video-stream",
+        "matchDate": "2026-05-15T14:30:00Z",
+        "domain": "https://verifier.example/",
+        "matchResult": "verified",
+        "confidence": "0.94"
+      }
+    },
+    "proof": {
+      "type": "DataIntegrityProof",
+      "cryptosuite": "ecdsa-rdfc-2019",
+      "created": "2026-05-15T14:30:05Z",
+      "verificationMethod": "did:web:realeyesit.com#key-1",
+      "proofPurpose": "assertionMethod",
+      "proofValue": "z58DAdFfa9SkqZMVPxAQpic7ndTeel..."
+    }
+  }
+        </pre>
+      </section>
+    </section>
   </section>
+
   <section>
     <h2>Assurance Levels</h2>
     <dl>

--- a/index.html
+++ b/index.html
@@ -777,9 +777,9 @@ method</a>, such as a public key, by
         "confidence": "0.96"
       }
     },
-    "proof": {
+"proof": {
       "type": "DataIntegrityProof",
-      "cryptosuite": "biometric-zkp-2026",
+      "cryptosuite": "example-biometric-zkp-2028",
       "created": "2026-05-15T14:30:05Z",
       "verificationMethod": "did:example:holder-device#key-1",
       "proofPurpose": "authentication",
@@ -787,6 +787,12 @@ method</a>, such as a public key, by
     }
   }
         </pre>
+        <p class="note">
+          The `example-biometric-zkp-2028` cryptosuite does not exist at the
+          time of this writing. It is included here to illustrate how a future
+          zero-knowledge proof cryptosuite could be used for client-side
+          biometric verification. This area is under active research.
+        </p>
       </section>
       <section>
         <h4>User-Selected Provider</h4>

--- a/index.html
+++ b/index.html
@@ -784,6 +784,7 @@ method</a>, such as a public key, by
       "type": "DataIntegrityProof",
       "cryptosuite": "example-biometric-zkp-2028",
       "created": "2026-05-15T14:30:05Z",
+      "challenge": "9a4f2c8b-3e7d-4f1a-b5c9-2d8e6f0a1b3c",
       "verificationMethod": "did:example:holder-device#key-1",
       "proofPurpose": "authentication",
       "proofValue": "z58DAdFfa9SkqZMVPxAQpic7ndTeel..."
@@ -898,6 +899,7 @@ method</a>, such as a public key, by
       "type": "DataIntegrityProof",
       "cryptosuite": "ecdsa-rdfc-2019",
       "created": "2026-05-15T14:30:05Z",
+      "challenge": "9a4f2c8b-3e7d-4f1a-b5c9-2d8e6f0a1b3c",
       "verificationMethod": "did:web:realeyesit.com#key-1",
       "proofPurpose": "assertionMethod",
       "proofValue": "z58DAdFfa9SkqZMVPxAQpic7ndTeel..."

--- a/index.html
+++ b/index.html
@@ -671,7 +671,7 @@ method</a>, such as a public key, by
         <dd>
           The value MUST be `BiometricVectorConfidenceMethod`.
         </dd>
-        <dt>`biometricType`</dt>
+        <dt>`biometricModality`</dt>
         <dd>
           The biometric modality. Expected values include `face`, `voice`,
           `fingerprint`, `palmprint`, `iris`, and `retina`.


### PR DESCRIPTION
Adds BiometricVectorConfidenceMethod subsection to Data Model, addressing #31. Two scenarios: client-side/local verification and user-selected provider. Per WG guidance on 2026-05-07 call.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/ScottJeezey/vc-confidence-method/pull/38.html" title="Last updated on Jun 18, 2026, 2:55 PM UTC (651979b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-confidence-method/38/0ef1f51...ScottJeezey:651979b.html" title="Last updated on Jun 18, 2026, 2:55 PM UTC (651979b)">Diff</a>