### PR TITLE
Add sections on cryptographic keys and controlled identifiers

### DIFF
--- a/index.html
+++ b/index.html
@@ -638,19 +638,12 @@ method</a>, such as a public key, by
         </p>
       </dd>
     </dl>
-    <section>
-      <h3>Verification Confidence</h3>
-      <p>TBD</p>
-    </section>
-    <section>
-      <h3>Biometric Image Confidence</h3>
-      <p>TBD</p>
-    </section>
+
     <section>
       <h3>Cryptographic Key</h3>
       <p>
 A cryptographic key confidence method enables an [=issuer=] to bind a specific
-public key, expressed using a format such as
+cryptographic public key, expressed using a format such as
 <a data-cite="VC-DATA-INTEGRITY#Multikey">Multikey</a> or
 <a data-cite="VC-DATA-INTEGRITY#JsonWebKey">JsonWebKey</a>, to a [=subject=] in
 a [=verifiable credential=]. The [=issuer=] records the public key that was in
@@ -658,38 +651,39 @@ the [=subject=]'s possession at the time of issuance, providing [=verifiers=]
 with a cryptographic anchor they can use to confirm that a presenter controls
 the corresponding private key. Because the binding is asserted by the [=issuer=]
 and protected by the credential's securing mechanism, a [=verifier=] can trust
-that the key material reflects what the [=issuer=] verified at issuance time.
+that the cryptographic key material reflects what the [=issuer=] verified at
+issuance time.
       </p>
 
-      <pre class="example" title="Cryptographic key confidence methods expressed in a verifiable credential">
+      <pre class="example nohighlight" title="Cryptographic key confidence methods expressed in a verifiable credential">
 {
   "@context": [
     "https://www.w3.org/ns/credentials/v2",
     "https://www.w3.org/ns/credentials/examples/v2"
   ],
-  "id": "http://example.edu/credentials/1234",
   "type": ["VerifiableCredential", "EmployeeCredential"],
   "issuer": "https://example.com/issuers/42",
-  "validFrom": "2024-01-15T00:00:00Z",
+  "validFrom": "2026-07-15T00:00:00Z",
   "credentialSubject": {
-    "id": "did:example:ebfeb1f712ebc6f1c276e12ec21",
     "name": "Alice Doe",
-    "confidenceMethod": [{
-      "id": "did:example:ebfeb1f712ebc6f1c276e12ec21#key-1",
+    <span class="highlight">"confidenceMethod": [{
+      <span class="comment">// express public key inline</span>
       "type": "Multikey",
-      "controller": "did:example:ebfeb1f712ebc6f1c276e12ec21",
       "publicKeyMultibase": "zH3C2AVvLMv6gmMNam3uVAjZpfkcJCwDwnZn6z3wXmqPV"
     }, {
-      "id": "urn:uuid:818d5ca0-3978-11f0-8658-4f17a1afd652#key-abc",
+      <span class="comment">// express public key by reference</span>
+      "id": "did:example:123456789#key-1",
+      "type": "Multikey"
+    }, {
+      <span class="comment">// multiple public key formats are supported</span>
       "type": "JsonWebKey",
-      "controller": "urn:uuid:818d5ca0-3978-11f0-8658-4f17a1afd652",
       "publicKeyJwk": {
         "crv": "Ed25519",
         "x": "VCpo2LMLhn6iWku8MKvSLg2ZAoC-nlOyPVQaO3FxVeQ",
         "kty": "OKP",
         "kid": "_Qq0UL2Fq651Q0Fjd6TvnYE-faHiOpRlPVQcY_-tA4A"
       }
-    }]
+    }]</span>
   },
   "proof": { <span class="comment">...</span> }
 }
@@ -727,23 +721,24 @@ requiring the [=issuer=] to reissue the [=verifiable credential=], so long as
 the [=subject=] maintains control of the identifier itself.
       </p>
 
-      <pre class="example" title="Controlled Identifier confidence method expressed in a verifiable credential">
+      <pre class="example nohighlight" title="Controlled Identifier confidence method expressed in a verifiable credential">
 {
   "@context": [
     "https://www.w3.org/ns/credentials/v2",
     "https://www.w3.org/ns/credentials/examples/v2"
   ],
-  "id": "http://example.edu/credentials/5678",
   "type": ["VerifiableCredential", "MembershipCredential"],
   "issuer": "https://example.org/issuers/7",
-  "validFrom": "2024-03-01T00:00:00Z",
+  "validFrom": "2026-07-01T00:00:00Z",
   "credentialSubject": {
-    "id": "did:example:ebfeb1f712ebc6f1c276e12ec21",
-    "memberSince": "2020-06-01",
-    "confidenceMethod": {
+    "name": "Alex Utopian"
+    "memberOf": {
+      "name": "Utopia Libraries"
+    },
+    <span class="highlight">"confidenceMethod": {
       "id": "did:example:ebfeb1f712ebc6f1c276e12ec21",
       "type": "DecentralizedIdentifierDocument"
-    }
+    }</span>
   },
   "proof": { <span class="comment">...</span> }
 }
@@ -766,6 +761,11 @@ protocol accommodates key rotation transparently: the [=holder=] may present
 using any currently authorized authentication key without requiring a new
 credential from the [=issuer=].
       </p>
+    </section>
+
+    <section>
+      <h3>Biometric Image Confidence</h3>
+      <p>TBD</p>
     </section>
 
     <section>

--- a/index.html
+++ b/index.html
@@ -735,10 +735,7 @@ the [=subject=] maintains control of the identifier itself.
     "memberOf": {
       "name": "Utopia Libraries"
     },
-    <span class="highlight">"confidenceMethod": {
-      "id": "did:example:ebfeb1f712ebc6f1c276e12ec21",
-      "type": "DecentralizedIdentifierDocument"
-    }</span>
+    <span class="highlight">"confidenceMethod": "did:example:ebfeb1f712ebc6f1c276e12ec21",</span>
   },
   "proof": { <span class="comment">...</span> }
 }

--- a/index.html
+++ b/index.html
@@ -647,6 +647,68 @@ method</a>, such as a public key, by
       <p>TBD</p>
     </section>
     <section>
+      <h3>Cryptographic Key</h3>
+      <p>
+A cryptographic key confidence method enables an [=issuer=] to bind a specific
+public key, expressed using a format such as
+<a data-cite="VC-DATA-INTEGRITY#Multikey">Multikey</a> or
+<a data-cite="VC-DATA-INTEGRITY#JsonWebKey">JsonWebKey</a>, to a [=subject=] in
+a [=verifiable credential=]. The [=issuer=] records the public key that was in
+the [=subject=]'s possession at the time of issuance, providing [=verifiers=]
+with a cryptographic anchor they can use to confirm that a presenter controls
+the corresponding private key. Because the binding is asserted by the [=issuer=]
+and protected by the credential's securing mechanism, a [=verifier=] can trust
+that the key material reflects what the [=issuer=] verified at issuance time.
+      </p>
+
+      <pre class="example" title="Cryptographic key confidence methods expressed in a verifiable credential">
+{
+  "@context": [
+    "https://www.w3.org/ns/credentials/v2",
+    "https://www.w3.org/ns/credentials/examples/v2"
+  ],
+  "id": "http://example.edu/credentials/1234",
+  "type": ["VerifiableCredential", "EmployeeCredential"],
+  "issuer": "https://example.com/issuers/42",
+  "validFrom": "2024-01-15T00:00:00Z",
+  "credentialSubject": {
+    "id": "did:example:ebfeb1f712ebc6f1c276e12ec21",
+    "name": "Alice Doe",
+    "confidenceMethod": [{
+      "id": "did:example:ebfeb1f712ebc6f1c276e12ec21#key-1",
+      "type": "Multikey",
+      "controller": "did:example:ebfeb1f712ebc6f1c276e12ec21",
+      "publicKeyMultibase": "zH3C2AVvLMv6gmMNam3uVAjZpfkcJCwDwnZn6z3wXmqPV"
+    }, {
+      "id": "urn:uuid:818d5ca0-3978-11f0-8658-4f17a1afd652#key-abc",
+      "type": "JsonWebKey",
+      "controller": "urn:uuid:818d5ca0-3978-11f0-8658-4f17a1afd652",
+      "publicKeyJwk": {
+        "crv": "Ed25519",
+        "x": "VCpo2LMLhn6iWku8MKvSLg2ZAoC-nlOyPVQaO3FxVeQ",
+        "kty": "OKP",
+        "kid": "_Qq0UL2Fq651Q0Fjd6TvnYE-faHiOpRlPVQcY_-tA4A"
+      }
+    }]
+  },
+  "proof": { <span class="comment">...</span> }
+}
+      </pre>
+
+      <p>
+During a [=verifiable presentation=], a [=verifier=] uses the public key in the
+confidence method to execute a proof-of-possession protocol. The [=verifier=]
+issues a cryptographic challenge, typically a nonce bound to the session, and
+the [=holder=] signs the challenge using the private key corresponding to the
+public key recorded in the confidence method. The [=verifier=] then verifies
+that signature against the asserted public key. A successful verification
+establishes that the presenter controls the private key the [=issuer=] bound to
+the [=subject=] at issuance, increasing confidence that the presenter is the
+intended [=subject=] of the [=verifiable credential=].
+      </p>
+    </section>
+
+    <section>
       <h3>Biometric Vector Confidence Method</h3>
 
       <div class="issue atrisk"

--- a/index.html
+++ b/index.html
@@ -709,6 +709,66 @@ intended [=subject=] of the [=verifiable credential=].
     </section>
 
     <section>
+      <h3>Controlled Identifier</h3>
+      <p>
+A controlled identifier confidence method enables an [=issuer=] to bind a
+[=subject=] to a
+<a data-cite="CID#dfn-controlled-identifier-document">controlled identifier
+document</a> that they control, rather than embedding a specific key directly in
+the [=verifiable credential=]. Decentralized Identifiers (DIDs) are one
+well-known type of controlled identifier. The [=issuer=] records the controlled
+identifier of the [=subject=] as verified at the time of issuance, allowing the
+[=verifier=] to retrieve the current controlled identifier document and discover
+the verification methods listed in the subject's
+<a data-cite="CID#dfn-authentication">authentication</a> verification
+relationship at presentation time. This approach accommodates key rotation and
+other lifecycle changes to the [=subject=]'s cryptographic material without
+requiring the [=issuer=] to reissue the [=verifiable credential=], so long as
+the [=subject=] maintains control of the identifier itself.
+      </p>
+
+      <pre class="example" title="Controlled Identifier confidence method expressed in a verifiable credential">
+{
+  "@context": [
+    "https://www.w3.org/ns/credentials/v2",
+    "https://www.w3.org/ns/credentials/examples/v2"
+  ],
+  "id": "http://example.edu/credentials/5678",
+  "type": ["VerifiableCredential", "MembershipCredential"],
+  "issuer": "https://example.org/issuers/7",
+  "validFrom": "2024-03-01T00:00:00Z",
+  "credentialSubject": {
+    "id": "did:example:ebfeb1f712ebc6f1c276e12ec21",
+    "memberSince": "2020-06-01",
+    "confidenceMethod": {
+      "id": "did:example:ebfeb1f712ebc6f1c276e12ec21",
+      "type": "DecentralizedIdentifierDocument"
+    }
+  },
+  "proof": { <span class="comment">...</span> }
+}
+      </pre>
+
+      <p>
+During a [=verifiable presentation=], the [=verifier=] resolves the controlled
+identifier in the confidence method to obtain the current controlled identifier
+document. The [=verifier=] extracts the
+<a data-cite="VC-DATA-INTEGRITY#dfn-verification-method">verification
+methods</a> listed in the
+<a data-cite="CID#dfn-authentication">authentication</a> verification
+relationship of that document, then issues a cryptographic challenge and
+requests that the [=holder=] produce a proof using one of those authentication
+verification methods. If the [=holder=] successfully signs the challenge with an
+authorized key, the [=verifier=] gains confidence that the presenter controls
+the identifier that the [=issuer=] associated with the [=subject=] at issuance.
+Because controlled identifier documents are maintained by the [=subject=], this
+protocol accommodates key rotation transparently: the [=holder=] may present
+using any currently authorized authentication key without requiring a new
+credential from the [=issuer=].
+      </p>
+    </section>
+
+    <section>
       <h3>Biometric Vector Confidence Method</h3>
 
       <div class="issue atrisk"


### PR DESCRIPTION
This PR is an attempt to address PR #37 by adding sections on cryptographic keys and controlled identifiers.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-confidence-method/pull/43.html" title="Last updated on Aug 9, 2026, 11:37 PM UTC (2302e44)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-confidence-method/43/c80ff78...2302e44.html" title="Last updated on Aug 9, 2026, 11:37 PM UTC (2302e44)">Diff</a>