### PR TITLE
Align with the original VCDM 2.0 definition

### DIFF
--- a/index.html
+++ b/index.html
@@ -221,11 +221,17 @@
   <section id="introduction" class="informative">
     <h2>Introduction</h2>
     <p>
-      Determining that a current presenter is the [=subject=] of a
-      [=Verifiable Credential=] is a key concern for verifiers.
+      This specification defines mechanisms that a verifier might use to
+      increase their confidence that the value of a property in or of a
+      verifiable credential or verifiable presentation is accurate.
     </p>
     <p>
-      This specification defines two extensible mechanisms that
+      In particular, determining that a current presenter is the
+      [=subject=] of a [=Verifiable Credential=] is a key concern for
+      verifiers.
+    </p>
+    <p>
+      To that end, it defines two extensible mechanisms that
       [=Issuers=]
       can use to help [=Verifiers=] increase their confidence that the
       presentation of a given Verifiable Credential is legitimate.

--- a/index.html
+++ b/index.html
@@ -227,7 +227,7 @@
     </p>
     <p>
       In particular, determining that a current presenter is a
-      particular [=subject=] of a [=Verifiable Credential=] is a key
+      particular [=subject=] of a [=verifiable credential=] is a key
       concern for verifiers.
     </p>
     <p>

--- a/index.html
+++ b/index.html
@@ -226,9 +226,9 @@
       verifiable credential or verifiable presentation is accurate.
     </p>
     <p>
-      In particular, determining that a current presenter is the
-      [=subject=] of a [=Verifiable Credential=] is a key concern for
-      verifiers.
+      In particular, determining that a current presenter is a
+      particular [=subject=] of a [=Verifiable Credential=] is a key
+      concern for verifiers.
     </p>
     <p>
       To that end, it defines two extensible mechanisms that


### PR DESCRIPTION
This resolves https://github.com/w3c/vc-confidence-method/issues/33 by keeping the original broader definition, leaving room for further development, and focusing this version on determining that a current presenter is the subject of a verifiable credential.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-confidence-method/pull/45.html" title="Last updated on Jul 30, 2026, 4:58 PM UTC (fe7ca76)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-confidence-method/45/c80ff78...fe7ca76.html" title="Last updated on Jul 30, 2026, 4:58 PM UTC (fe7ca76)">Diff</a>