### PR TITLE
Editorial cleanup: sections, title, tooling

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-# Verifiable Credential Confidence Methods
+# Verifiable Credential Confidence
 
 This specification defines a mechanism that can be used with the Verifiable Credentials Data Model v2.0 to increase a verifier's confidence about a particular subject identified in a verifiable credential.
 
 The latest specification can be viewed at the following link:
 
-[https://w3c-ccg.github.io/vc-confidence-method/](https://w3c-ccg.github.io/vc-confidence-method/)
+[https://w3c.github.io/vc-confidence-method/](https://w3c.github.io/vc-confidence-method/)

--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 
 <head>
   <meta charset="utf-8">
-  <title>Verifiable Credential Confidence v1.0</title>
+  <title>Verifiable Credential Confidence Methods v1.0</title>
   <script src="https://www.w3.org/Tools/respec/respec-w3c"
     class="remove"></script>
   <script class="remove"

--- a/index.html
+++ b/index.html
@@ -3,17 +3,18 @@
 
 <head>
   <meta charset="utf-8">
-  <title>Confidence Method v1.0</title>
+  <title>Verifiable Credential Confidence v1.0</title>
   <script src="https://www.w3.org/Tools/respec/respec-w3c"
     class="remove"></script>
   <script class="remove"
-    src="https://cdn.jsdelivr.net/gh/w3c/respec-vc@3.4.3/dist/main.js">
+    src="https://cdn.jsdelivr.net/gh/w3c/respec-vc@3.5.1/dist/main.js">
     </script>
   <script class="remove">
     // All config options at https://respec.org/docs/
     var respecConfig = {
       specStatus: "FPWD",
-      publishDate: "2025-10-30",
+      // https://respec.org/docs/#publishDate
+      // publishDate: "2025-10-30",
       editors: [{
         name: "Joe Andrieu",
         url: "https://www.linkedin.com/in/joe-andrieu/",
@@ -320,6 +321,31 @@
         a biometric.
       </li>
     </ul>
+
+    <section class="normative">
+      <h3>Terminology</h3>
+      <p>
+        Some terminology used throughout this document is defined in the
+        <a data-cite="VC-DATA-MODEL-2.0#terminology">Terminology</a>
+        section of the [[[VC-DATA-MODEL-2.0]]] specification as well as
+        the
+        <a data-cite="CID#terminology">Terminology</a> section of the
+        [[[CID]]] specification. This section defines addition terms
+        used
+        throughout this specification.
+      </p>
+
+      <dl class="termlist definitions" data-sort="ascending">
+        <dt><dfn class="export">assurance level</dfn></dt>
+        <dd>
+          A technique for establishing the identity of an individual in
+          terms of real-world evidence and observations, according to a
+          specific process, typically defined by national and
+          international standards organizations like NIST in the US and
+          eIDAS in the EU.
+        </dd>
+      </dl>
+    </section>
   </section>
   <section id="conformance">
     <p>
@@ -466,7 +492,6 @@ method</a>, such as a public key, by
 
     <dl>
       <dt><dfn>confidenceMethod</dfn></dt>
-      <dd>
       <dd>
         <p>
           If present, the value of the `confidenceMethod` property is
@@ -991,6 +1016,7 @@ method</a>, such as a public key, by
         </pre>
       </section>
     </section>
+  </section>
 
   <section>
     <h2>Assurance Levels</h2>
@@ -1007,36 +1033,13 @@ method</a>, such as a public key, by
       </dd>
     </dl>
     <section>
-      <h3>NIST_800-63-3_LOA</h3>
+      <h3>NIST_800-63-4_LOA</h3>
       <p>TBD</p>
     </section>
     <section>
       <h3>EIDAS_LOA</h3>
       <p>TBD</p>
     </section>
-  </section>
-  <section class="normative">
-    <h2>Terminology</h2>
-    <p>
-      Some terminology used throughout this document is defined in the
-      <a data-cite="VC-DATA-MODEL-2.0#terminology">Terminology</a>
-      section of the [[[VC-DATA-MODEL-2.0]]] specification as well as
-      the
-      <a data-cite="CID#terminology">Terminology</a> section of the
-      [[[CID]]] specification. This section defines addition terms
-      used
-      throughout this specification.
-    </p>
-
-    <dl class="termlist definitions" data-sort="ascending">
-      <dt><dfn class="export">assurance level</dfn></dt>
-      <dd>
-        A technique for establishing the identity of an individual in
-        terms of real-world evidence and observations, according to a
-        specific process, typically defined by national and
-        international standards organizations like NIST in the US and
-        eIDAS in the EU.
-      </dd>
   </section>
   <section>
     <h2>Security Considerations</h2>


### PR DESCRIPTION
Two related things may still need discussion: 
1. Should we change the title: `Confidence Method v1.0` → `Verifiable Credential Confidence v1.0`, as we proposed in the [current VCWG charter](https://www.w3.org/2026/03/vc-wg-charter.html#confidence). Related issue about short url: https://github.com/w3c/vc-confidence-method/issues/46
2. Should `Assurance Levels` be at the same level as `Confidence Methods`, should it be a child element of `Confidence Methods`?


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-confidence-method/pull/47.html" title="Last updated on Aug 17, 2026, 4:23 PM UTC (bf3a623)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-confidence-method/47/c80ff78...bf3a623.html" title="Last updated on Aug 17, 2026, 4:23 PM UTC (bf3a623)">Diff</a>